### PR TITLE
A very basic lexer.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "lrlex"
+version = "0.1.0"
+authors = ["Laurence Tratt <http://tratt.net/laurie/>"]
+
+[[bin]]
+doc = false
+name = "lrlex"
+
+[lib]
+name = "lrlex"
+path = "src/lib/mod.rs"
+
+[dependencies]
+getopts = "0.2.14" # only needed for src/main.rs
+lazy_static = "0.2.2"
+regex = "0.2.1"

--- a/src/lib/ast.rs
+++ b/src/lib/ast.rs
@@ -1,0 +1,47 @@
+use std::collections::HashMap;
+use regex::Regex;
+
+pub struct LexAST {
+    pub rules: Vec<Rule>
+}
+
+impl LexAST {
+    pub fn new() -> LexAST {
+        LexAST {rules: Vec::new()}
+    }
+
+    /// Appends a rule to the Vec of rules. Panics if a rule with the same name already exists.
+    pub fn set_rule(&mut self, r: Rule) {
+        assert!(r.name.is_none() || self.get_rule(&r.name.as_ref().unwrap()).is_none());
+        self.rules.push(r);
+    }
+
+    /// Get the `Rule` instance associated with a particular name.
+    pub fn get_rule(&self, n: &str) -> Option<&Rule> {
+        self.rules.iter().find(|r| !r.name.is_none() && r.name.as_ref().unwrap() == n)
+    }
+
+    /// Set the id attribute on rules to the corresponding value in `map`. This is typically used
+    /// to synchronise a parser's notion of token IDs with the lexers.
+    pub fn set_rule_ids(&mut self, map: &HashMap<&str, usize>) {
+        for r in self.rules.iter_mut() {
+            match r.name.as_ref() {
+                None => (),
+                Some(n) => {
+                    r.id = *map.get(&**n).unwrap()
+                }
+            };
+        }
+    }
+}
+
+pub struct Rule {
+    /// The ID of this rule as set by the client/parser. Its initial value is usize::max_value().
+    pub id: usize,
+    /// This rule's name. If None, then text which matches this rule will be skipped (i.e. will not
+    /// create a lexeme).
+    pub name: Option<String>,
+    pub re_str: String,
+    pub re: Regex
+}
+

--- a/src/lib/lexer.rs
+++ b/src/lib/lexer.rs
@@ -1,0 +1,84 @@
+use ast::LexAST;
+
+#[derive(Debug)]
+pub struct Lexeme {
+    pub rule_idx: usize,
+    /// Byte offset of the start of the lexeme
+    pub start: usize,
+    /// Length in bytes of the lexeme
+    pub len: usize
+}
+
+#[derive(Debug)]
+pub struct LexError {
+    idx: usize
+}
+
+pub fn lex(ast: &LexAST, s: &str) -> Result<Vec<Lexeme>, LexError> {
+    let mut i = 0; // byte index into s
+    let mut lxs = Vec::new(); // lexemes
+    'n: while i < s.len() {
+        for (r_idx, r) in ast.rules.iter().enumerate() {
+            match r.re.find(&s[i..]) {
+                None => continue,
+                Some(m) => {
+                    if r.name.is_some() {
+                        lxs.push(Lexeme{rule_idx: r_idx, start: i, len: m.end()});
+                    }
+                    i += m.end();
+                    continue 'n;
+                }
+            }
+        }
+        return Err(LexError{idx: i});
+    }
+    Ok(lxs)
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::HashMap;
+    use super::*;
+    use parser::parse_lex;
+
+    #[test]
+    fn test_basic() {
+        let src = r"
+%%
+[0-9]+ int
+[a-zA-Z]+ id
+[ \t] ;
+        ".to_string();
+        let mut ast = parse_lex(&src).unwrap();
+        let mut map = HashMap::new();
+        map.insert("int", 0);
+        map.insert("id", 1);
+        ast.set_rule_ids(&map);
+
+        let lexemes = lex(&ast, "abc 123").unwrap();
+        assert_eq!(lexemes.len(), 2);
+        let lex1 = lexemes.get(0).unwrap();
+        assert_eq!(lex1.rule_idx, 1);
+        assert_eq!(lex1.start, 0);
+        assert_eq!(lex1.len, 3);
+        let lex2 = lexemes.get(1).unwrap();
+        assert_eq!(lex2.rule_idx, 0);
+        assert_eq!(lex2.start, 4);
+        assert_eq!(lex2.len, 3);
+    }
+
+
+    #[test]
+    fn test_basic_error() {
+        let src = "
+%%
+[0-9]+ int
+        ".to_string();
+        let ast = parse_lex(&src).unwrap();
+        match lex(&ast, "abc") {
+            Ok(_)  => panic!("Invalid input lexed"),
+            Err(LexError{idx: 0}) => (),
+            Err(e) => panic!("Incorrect error returned {:?}", e)
+        };
+    }
+}

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -1,0 +1,60 @@
+extern crate regex;
+
+use std::fmt;
+
+pub mod ast;
+mod lexer;
+mod parser;
+
+use ast::LexAST;
+use lexer::{lex, Lexeme, LexError};
+use parser::parse_lex;
+
+#[macro_use]
+extern crate lazy_static;
+
+pub type LexBuildResult<T> = Result<T, LexBuildError>;
+
+/// Any error from the Lex parser returns an instance of this struct.
+#[derive(Debug)]
+pub struct LexBuildError {
+    pub kind: LexErrorKind,
+    line: usize,
+    col: usize
+}
+
+/// The various different possible Lex parser errors.
+#[derive(Debug)]
+pub enum LexErrorKind {
+    PrematureEnd,
+    RoutinesNotSupported,
+    UnknownDeclaration,
+    MissingSpace,
+    InvalidName,
+    DuplicateName,
+    RegexError
+}
+
+impl fmt::Display for LexBuildError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let s;
+        match self.kind {
+            LexErrorKind::PrematureEnd         => s = "File ends prematurely",
+            LexErrorKind::RoutinesNotSupported => s = "Routines not currently supported",
+            LexErrorKind::UnknownDeclaration   => s = "Unknown declaration",
+            LexErrorKind::MissingSpace         => s = "Rule is missing a space",
+            LexErrorKind::InvalidName          => s = "Invalid rule name",
+            LexErrorKind::DuplicateName        => s = "Rule name already exists",
+            LexErrorKind::RegexError           => s = "Invalid regular expression"
+        }
+        write!(f, "{} at line {} column {}", s, self.line, self.col)
+    }
+}
+
+pub fn build_lex(s: &str) -> Result<LexAST, LexBuildError> {
+    parse_lex(s)
+}
+
+pub fn do_lex(ast: &LexAST, s: &str) -> Result<Vec<Lexeme>, LexError> {
+    lex(&ast, s)
+}

--- a/src/lib/parser.rs
+++ b/src/lib/parser.rs
@@ -1,0 +1,246 @@
+use regex::Regex;
+
+use {LexErrorKind, LexBuildError, LexBuildResult};
+
+use ast::{Rule, LexAST};
+
+pub struct LexParser {
+    src: String,
+    newlines: Vec<usize>,
+    ast: LexAST
+}
+
+lazy_static! {
+    static ref RE_NAME: Regex = {
+        Regex::new(r"^[a-zA-Z_][a-zA-Z_0-9]*$").unwrap()
+    };
+}
+
+impl LexParser {
+    fn new(src: String) -> LexParser {
+        LexParser{
+            src     : src,
+            newlines: vec![0],
+            ast     : LexAST::new()
+        }
+    }
+
+    fn mk_error(&self, k: LexErrorKind, off: usize) -> LexBuildError {
+        let (line, col) = self.off_to_line_col(off);
+        LexBuildError{kind: k, line: line, col: col}
+    }
+
+    fn off_to_line_col(&self, off: usize) -> (usize, usize) {
+        if off == self.src.len() {
+            let line_off = *self.newlines.iter().last().unwrap();
+            return (self.newlines.len(), self.src[line_off..].chars().count() + 1);
+        }
+        let (line_m1, &line_off) = self.newlines.iter()
+                                                .enumerate()
+                                                .rev()
+                                                .find(|&(_, &line_off)| line_off <= off)
+                                                .unwrap();
+        let c_off = self.src[line_off..]
+                        .char_indices()
+                        .position(|(c_off, _)| c_off == off - line_off)
+                        .unwrap();
+        return (line_m1 + 1, c_off + 1);
+    }
+
+    fn parse(&mut self) -> LexBuildResult<usize> {
+        let mut i = try!(self.parse_declarations(0));
+        i = try!(self.parse_rules(i));
+        // We don't currently support the subroutines part of a specification. One day we might...
+        match self.lookahead_is("%%", i) {
+            Some(j) => {
+                if try!(self.parse_ws(j)) == self.src.len() { Ok(i) }
+                else {
+                    Err(self.mk_error(LexErrorKind::RoutinesNotSupported, i))
+                }
+            }
+            None    => Ok(i)
+        }
+    }
+
+    fn parse_declarations(&mut self, mut i: usize) -> LexBuildResult<usize> {
+        i = try!(self.parse_ws(i));
+        if let Some(j) = self.lookahead_is("%%", i) { return Ok(j); }
+        if i < self.src.len() {
+            Err(self.mk_error(LexErrorKind::UnknownDeclaration, i))
+        }
+        else {
+            Err(self.mk_error(LexErrorKind::PrematureEnd, i - 1))
+        }
+    }
+
+    fn parse_rules(&mut self, mut i: usize) -> LexBuildResult<usize> {
+        loop {
+            i = try!(self.parse_ws(i));
+            if i == self.src.len() { break; }
+            if self.lookahead_is("%%", i).is_some() { break; }
+            i = try!(self.parse_rule(i));
+        }
+        Ok(i)
+    }
+
+    fn parse_rule(&mut self, i: usize) -> LexBuildResult<usize> {
+        let line_len = self.src[i..]
+                           .find(|c| c == '\n')
+                           .unwrap_or(self.src.len() - i);
+        let line     = self.src[i..i + line_len].trim_right();
+        let rspace   = match line.rfind(' ') {
+            Some(j) => j,
+            None    => return Err(self.mk_error(LexErrorKind::MissingSpace, i))
+        };
+
+        let name;
+        let orig_name = &line[rspace + 1..];
+        if orig_name == ";" {
+            name = None;
+        }
+        else if self.ast.get_rule(orig_name).is_some() {
+            return Err(self.mk_error(LexErrorKind::DuplicateName, i + rspace + 1))
+        }
+        else {
+            if !RE_NAME.is_match(&orig_name) {
+                return Err(self.mk_error(LexErrorKind::InvalidName, i + rspace + 1))
+            }
+            name = Some(orig_name.to_string());
+        }
+
+        let re_str = line[..rspace].trim_right().to_string();
+        let re = match Regex::new(&format!("^(?:{})", &re_str)) {
+            Ok(x) => x,
+            Err(_)  => return Err(self.mk_error(LexErrorKind::RegexError, i))
+        };
+        self.ast.set_rule(Rule{id: usize::max_value(),
+                               name: name,
+                               re: re,
+                               re_str: re_str});
+        Ok(i + line_len)
+    }
+
+    fn parse_ws(&mut self, i: usize) -> LexBuildResult<usize> {
+        let mut j = i;
+        for c in self.src[i..].chars() {
+            match c {
+                ' '  | '\t' => (),
+                '\n' | '\r' => self.newlines.push(j + 1),
+                _           => break
+            }
+            j += c.len_utf8();
+        }
+        Ok(j)
+    }
+
+    fn lookahead_is(&self, s: &'static str, i: usize) -> Option<usize> {
+        if self.src[i..].starts_with(s) {
+            Some(i + s.len())
+        }
+        else {
+            None
+        }
+    }
+}
+
+pub fn parse_lex(s: &str) -> Result<LexAST, LexBuildError> {
+    let mut lp = LexParser::new(s.to_string());
+    match lp.parse() {
+        Ok(_) => Ok(lp.ast),
+        Err(e) => Err(e)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use {LexBuildError, LexErrorKind};
+
+    #[test]
+    fn test_nooptions() {
+        let src = "
+%option nounput
+        ".to_string();
+        assert!(parse_lex(&src).is_err());
+    }
+
+    #[test]
+    fn test_minimum() {
+        let src = "%%".to_string();
+        assert!(parse_lex(&src).is_ok());
+    }
+
+    #[test]
+    fn test_rules() {
+        let src = "%%
+[0-9]+ int
+[a-zA-Z]+ id
+".to_string();
+        let ast = parse_lex(&src).unwrap();
+        let intrule = ast.get_rule("int").unwrap();
+        assert_eq!("int", intrule.name.as_ref().unwrap());
+        assert_eq!("[0-9]+", intrule.re_str);
+        let idrule = ast.get_rule("id").unwrap();
+        assert_eq!("id", idrule.name.as_ref().unwrap());
+        assert_eq!("[a-zA-Z]+", idrule.re_str);
+    }
+
+    #[test]
+    fn test_no_name() {
+        let src = "%%
+[0-9]+ ;
+".to_string();
+        let ast = parse_lex(&src).unwrap();
+        let intrule = ast.rules.get(0).unwrap();
+        assert!(intrule.name.is_none());
+        assert_eq!("[0-9]+", intrule.re_str);
+    }
+
+    #[test]
+    fn test_broken_rule() {
+        let src = "%%
+[0-9]
+int".to_string();
+        assert!(parse_lex(&src).is_err());
+        match parse_lex(&src) {
+            Ok(_)  => panic!("Broken rule parsed"),
+            Err(LexBuildError{kind: LexErrorKind::MissingSpace, line: 2, col: 1}) => (),
+            Err(e) => panic!("Incorrect error returned {}", e)
+        }
+    }
+
+    #[test]
+    fn test_broken_rule2() {
+        let src = "%%
+[0-9] ".to_string();
+        assert!(parse_lex(&src).is_err());
+        match parse_lex(&src) {
+            Ok(_)  => panic!("Broken rule parsed"),
+            Err(LexBuildError{kind: LexErrorKind::MissingSpace, line: 2, col: 1}) => (),
+            Err(e) => panic!("Incorrect error returned {}", e)
+        }
+    }
+
+    #[test]
+    fn test_invalid_name() {
+        let src = "%%
+[0-9] int.2".to_string();
+        match parse_lex(&src) {
+            Ok(_)  => panic!("Invalid name parsed"),
+            Err(LexBuildError{kind: LexErrorKind::InvalidName, line: 2, col: 7}) => (),
+            Err(e) => panic!("Incorrect error returned {}", e)
+        }
+    }
+
+    #[test]
+    fn test_duplicate_rule() {
+        let src = "%%
+[0-9] int
+[0-9] int".to_string();
+        match parse_lex(&src) {
+            Ok(_)  => panic!("Duplicate rule parsed"),
+            Err(LexBuildError{kind: LexErrorKind::DuplicateName, line: 3, col: 7}) => (),
+            Err(e) => panic!("Incorrect error returned {}", e)
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,66 @@
+extern crate getopts;
+extern crate lrlex;
+
+use getopts::Options;
+use std::{env, process};
+use std::fs::File;
+use std::io::{Read, stderr, Write};
+use std::path::Path;
+
+use lrlex::{build_lex, do_lex};
+
+fn usage(prog: String, msg: &str) {
+    let path = Path::new(prog.as_str());
+    let leaf = match path.file_name() {
+        Some(m) => m.to_str().unwrap(),
+        None => "lrpar"
+    };
+    if msg.len() > 0 {
+        writeln!(&mut stderr(), "{}", msg).ok();
+    }
+    writeln!(&mut stderr(), "Usage: {} <lexer.l> <input file>", leaf).ok();
+    process::exit(1);
+}
+
+fn read_file(path: &str) -> String {
+    let mut f = match File::open(path) {
+        Ok(r) => r,
+        Err(e) => {
+            writeln!(&mut stderr(), "Can't open file {}: {}", path, e).ok();
+            process::exit(1);
+        }
+    };
+    let mut s = String::new();
+    f.read_to_string(&mut s).unwrap();
+    s
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let prog = args[0].clone();
+    let matches = match Options::new()
+                                .optflag("h", "help", "")
+                                .parse(&args[1..]) {
+        Ok(m) => m,
+        Err(f) => { usage(prog, f.to_string().as_str()); return }
+    };
+
+    if matches.opt_present("h") || matches.free.len() != 2 {
+        usage(prog, "");
+        return;
+    }
+
+    let lex_l_path = &matches.free[0];
+    let lex_ast = match build_lex(&read_file(lex_l_path)) {
+        Ok(ast) => ast,
+        Err(s) => {
+            writeln!(&mut stderr(), "{}: {}", &lex_l_path, &s).ok();
+            process::exit(1);
+        }
+    };
+    let input = &read_file(&matches.free[1]);
+    let lexemes = do_lex(&lex_ast, &input).unwrap();
+    for l in lexemes.iter() {
+        println!("{} {}", lex_ast.rules.get(l.rule_idx).unwrap().name.as_ref().unwrap(), &input[l.start..l.start + l.len]);
+    }
+}


### PR DESCRIPTION
This uses Rust's regular expression crate in lieu of a guaranteed-lex-compatible equivalent. The internals are overly simplistic, and there are a couple of places where if you do the wrong thing, it panics. But it does work in a very crude and basic sort of way.

`main.rs` currently prints out the list of tokens for a file. If I feed it a (lightly modified) Java lex file and a test file I get this:
```
$ cat hello.java
class C { int x = 2; }
$ cargo run java.l hello.java
CLASS class
IDENTIFIER C
LBRACE {
INT int
IDENTIFIER x
EQ =
INTEGER_LITERAL 2
SEMICOLON ;
RBRACE }
```

There'll need to be a *lot* more work on this in the future, but this is at least the rough sort of base needed to start working on the LR parser (in a separate repo).