### PR TITLE
Interact with lrpar

### DIFF
--- a/src/lib/ast.rs
+++ b/src/lib/ast.rs
@@ -12,12 +12,17 @@ impl LexAST {
 
     /// Appends a rule to the Vec of rules. Panics if a rule with the same name already exists.
     pub fn set_rule(&mut self, r: Rule) {
-        assert!(r.name.is_none() || self.get_rule(&r.name.as_ref().unwrap()).is_none());
+        assert!(r.name.is_none() || self.get_rule_by_name(&r.name.as_ref().unwrap()).is_none());
         self.rules.push(r);
     }
 
+    /// Get the `Rule` instance associated with a particular token ID.
+    pub fn get_rule_by_id(&self, tok_id: usize) -> Option<&Rule> {
+        self.rules.iter().find(|r| r.tok_id == tok_id)
+    }
+
     /// Get the `Rule` instance associated with a particular name.
-    pub fn get_rule(&self, n: &str) -> Option<&Rule> {
+    pub fn get_rule_by_name(&self, n: &str) -> Option<&Rule> {
         self.rules.iter().find(|r| !r.name.is_none() && r.name.as_ref().unwrap() == n)
     }
 
@@ -28,7 +33,7 @@ impl LexAST {
             match r.name.as_ref() {
                 None => (),
                 Some(n) => {
-                    r.id = *map.get(&**n).unwrap()
+                    r.tok_id = *map.get(&**n).unwrap()
                 }
             };
         }
@@ -36,8 +41,9 @@ impl LexAST {
 }
 
 pub struct Rule {
-    /// The ID of this rule as set by the client/parser. Its initial value is usize::max_value().
-    pub id: usize,
+    /// The ID that tokens created against this rule will be given. It is initially given a
+    /// guaranteed unique value; that value can be overridden by clients.
+    pub tok_id: usize,
     /// This rule's name. If None, then text which matches this rule will be skipped (i.e. will not
     /// create a lexeme).
     pub name: Option<String>,

--- a/src/lib/lexer.rs
+++ b/src/lib/lexer.rs
@@ -2,7 +2,7 @@ use ast::LexAST;
 
 #[derive(Debug)]
 pub struct Lexeme {
-    pub rule_idx: usize,
+    pub tok_id: usize,
     /// Byte offset of the start of the lexeme
     pub start: usize,
     /// Length in bytes of the lexeme
@@ -17,6 +17,7 @@ pub struct LexError {
 pub fn lex(ast: &LexAST, s: &str) -> Result<Vec<Lexeme>, LexError> {
     let mut i = 0; // byte index into s
     let mut lxs = Vec::new(); // lexemes
+
     while i < s.len() {
         let mut longest = 0; // Length of the longest match
         let mut longest_ridx = 0; // This is only valid iff longest != 0
@@ -34,7 +35,7 @@ pub fn lex(ast: &LexAST, s: &str) -> Result<Vec<Lexeme>, LexError> {
         if longest > 0 {
             let r = ast.rules.get(longest_ridx).unwrap();
             if r.name.is_some() {
-                lxs.push(Lexeme{rule_idx: longest_ridx, start: i, len: longest});
+                lxs.push(Lexeme{tok_id: r.tok_id, start: i, len: longest});
             }
             i += longest;
         } else {
@@ -67,11 +68,11 @@ mod test {
         let lexemes = lex(&ast, "abc 123").unwrap();
         assert_eq!(lexemes.len(), 2);
         let lex1 = lexemes.get(0).unwrap();
-        assert_eq!(lex1.rule_idx, 1);
+        assert_eq!(lex1.tok_id, 1);
         assert_eq!(lex1.start, 0);
         assert_eq!(lex1.len, 3);
         let lex2 = lexemes.get(1).unwrap();
-        assert_eq!(lex2.rule_idx, 0);
+        assert_eq!(lex2.tok_id, 0);
         assert_eq!(lex2.start, 4);
         assert_eq!(lex2.len, 3);
     }
@@ -106,11 +107,11 @@ if IF
         println!("{:?}", lexemes);
         assert_eq!(lexemes.len(), 2);
         let lex1 = lexemes.get(0).unwrap();
-        assert_eq!(lex1.rule_idx, 1);
+        assert_eq!(lex1.tok_id, 1);
         assert_eq!(lex1.start, 0);
         assert_eq!(lex1.len, 3);
         let lex2 = lexemes.get(1).unwrap();
-        assert_eq!(lex2.rule_idx, 0);
+        assert_eq!(lex2.tok_id, 0);
         assert_eq!(lex2.start, 4);
         assert_eq!(lex2.len, 2);
     }

--- a/src/lib/lexer.rs
+++ b/src/lib/lexer.rs
@@ -1,6 +1,6 @@
 use ast::LexAST;
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Lexeme {
     pub tok_id: usize,
     /// Byte offset of the start of the lexeme

--- a/src/lib/lexer.rs
+++ b/src/lib/lexer.rs
@@ -33,7 +33,7 @@ pub fn lex(ast: &LexAST, s: &str) -> Result<Vec<Lexeme>, LexError> {
             }
         }
         if longest > 0 {
-            let r = ast.rules.get(longest_ridx).unwrap();
+            let r = &ast.rules[longest_ridx];
             if r.name.is_some() {
                 lxs.push(Lexeme{tok_id: r.tok_id, start: i, len: longest});
             }

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -7,7 +7,8 @@ mod lexer;
 mod parser;
 
 use ast::LexAST;
-use lexer::{lex, Lexeme, LexError};
+pub use lexer::Lexeme;
+use lexer::{lex, LexError};
 use parser::parse_lex;
 
 #[macro_use]

--- a/src/lib/parser.rs
+++ b/src/lib/parser.rs
@@ -1,4 +1,4 @@
-use regex::Regex;
+use regex::{Regex, RegexBuilder};
 
 use {LexErrorKind, LexBuildError, LexBuildResult};
 
@@ -109,7 +109,10 @@ impl LexParser {
         }
 
         let re_str = line[..rspace].trim_right().to_string();
-        let re = match Regex::new(&format!("^(?:{})", &re_str)) {
+        let re = match RegexBuilder::new(&format!("\\A(?:{})", &re_str))
+                                    .multi_line(true)
+                                    .dot_matches_new_line(true)
+                                    .build() {
             Ok(x) => x,
             Err(_)  => return Err(self.mk_error(LexErrorKind::RegexError, i))
         };

--- a/src/lib/parser.rs
+++ b/src/lib/parser.rs
@@ -98,7 +98,7 @@ impl LexParser {
         if orig_name == ";" {
             name = None;
         }
-        else if self.ast.get_rule(orig_name).is_some() {
+        else if self.ast.get_rule_by_name(orig_name).is_some() {
             return Err(self.mk_error(LexErrorKind::DuplicateName, i + rspace + 1))
         }
         else {
@@ -113,7 +113,8 @@ impl LexParser {
             Ok(x) => x,
             Err(_)  => return Err(self.mk_error(LexErrorKind::RegexError, i))
         };
-        self.ast.set_rule(Rule{id: usize::max_value(),
+        let rules_len = self.ast.rules.len();
+        self.ast.set_rule(Rule{tok_id: rules_len,
                                name: name,
                                re: re,
                                re_str: re_str});
@@ -177,10 +178,10 @@ mod test {
 [a-zA-Z]+ id
 ".to_string();
         let ast = parse_lex(&src).unwrap();
-        let intrule = ast.get_rule("int").unwrap();
+        let intrule = ast.get_rule_by_name("int").unwrap();
         assert_eq!("int", intrule.name.as_ref().unwrap());
         assert_eq!("[0-9]+", intrule.re_str);
-        let idrule = ast.get_rule("id").unwrap();
+        let idrule = ast.get_rule_by_name("id").unwrap();
         assert_eq!("id", idrule.name.as_ref().unwrap());
         assert_eq!("[a-zA-Z]+", idrule.re_str);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,6 +61,6 @@ fn main() {
     let input = &read_file(&matches.free[1]);
     let lexemes = do_lex(&lex_ast, &input).unwrap();
     for l in lexemes.iter() {
-        println!("{} {}", lex_ast.rules.get(l.rule_idx).unwrap().name.as_ref().unwrap(), &input[l.start..l.start + l.len]);
+        println!("{} {}", lex_ast.get_rule_by_id(l.tok_id).unwrap().name.as_ref().unwrap(), &input[l.start..l.start + l.len]);
     }
 }


### PR DESCRIPTION
A few not-very-related changes needed to interact properly with lrpar. The commits have extra details on them which hopefully explain things (particularly the "move from rule IDs" commit).