### PR TITLE
Add a mechanism for getting line numbers for lexemes.

### DIFF
--- a/src/lib/lexer.rs
+++ b/src/lib/lexer.rs
@@ -99,21 +99,21 @@ impl<TokId: Copy + Eq> LexerDef<TokId> {
     }
 
     /// Return a lexer for the `String` `s` that will lex relative to this `LexerDef`.
-    pub fn lexer<'a>(&'a self, s: &'a String) -> Lexer<'a, TokId> {
+    pub fn lexer<'a>(&'a self, s: &'a str) -> Lexer<'a, TokId> {
         Lexer::new(&self, s)
     }
 }
 
-/// A lexer holds a reference to a `String` and can lex it into `Lexeme`s. Although the struct is
-/// tied to a single `String`, no guarantees are made about whether the lexemes are cached or not.
+/// A lexer holds a reference to a string and can lex it into `Lexeme`s. Although the struct is
+/// tied to a single string, no guarantees are made about whether the lexemes are cached or not.
 pub struct Lexer<'a, TokId: 'a> {
     lexerdef: &'a LexerDef<TokId>,
-    s: &'a String,
+    s: &'a str,
     newlines: Rc<RefCell<Vec<usize>>>
 }
 
 impl<'a, TokId: Copy + Eq> Lexer<'a, TokId> {
-    fn new(lexerdef: &'a LexerDef<TokId>, s: &'a String) -> Lexer<'a, TokId> {
+    fn new(lexerdef: &'a LexerDef<TokId>, s: &'a str) -> Lexer<'a, TokId> {
         Lexer {lexerdef, s, newlines: Rc::new(RefCell::new(Vec::new()))}
     }
 
@@ -205,8 +205,6 @@ impl<TokId: Copy> Lexeme<TokId> {
     }
 }
 
-
-
 #[cfg(test)]
 mod test {
     use std::collections::HashMap;
@@ -227,7 +225,7 @@ mod test {
         map.insert("id", 1);
         lexer.set_rule_ids(&map);
 
-        let lexemes = lexer.lexer(&"abc 123".to_string()).lexemes().unwrap();
+        let lexemes = lexer.lexer(&"abc 123").lexemes().unwrap();
         assert_eq!(lexemes.len(), 2);
         let lex1 = lexemes[0];
         assert_eq!(lex1.tok_id, 1);
@@ -246,7 +244,7 @@ mod test {
 [0-9]+ int
         ".to_string();
         let lexer = parse_lex::<u8>(&src).unwrap();
-        match lexer.lexer(&"abc".to_string()).lexemes() {
+        match lexer.lexer(&"abc").lexemes() {
             Ok(_)  => panic!("Invalid input lexed"),
             Err(LexError{idx: 0}) => (),
             Err(e) => panic!("Incorrect error returned {:?}", e)
@@ -265,7 +263,7 @@ if IF
         map.insert("ID", 1);
         lexer.set_rule_ids(&map);
 
-        let lexemes = lexer.lexer(&"iff if".to_string()).lexemes().unwrap();
+        let lexemes = lexer.lexer(&"iff if").lexemes().unwrap();
         assert_eq!(lexemes.len(), 2);
         let lex1 = lexemes[0];
         assert_eq!(lex1.tok_id, 1);
@@ -287,7 +285,7 @@ if IF
         map.insert("ID", 0);
         lexer.set_rule_ids(&map);
 
-        let stream = " a\nb\n  c".to_string();
+        let stream = " a\nb\n  c";
         let lexer = lexer.lexer(&stream);
         let lexemes = lexer.lexemes().unwrap();
         assert_eq!(lexemes.len(), 3);

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -40,7 +40,7 @@ use std::fmt;
 mod lexer;
 mod parser;
 
-pub use lexer::{Lexeme, Lexer};
+pub use lexer::{Lexeme, LexerDef, Lexer};
 use parser::parse_lex;
 
 #[macro_use]
@@ -84,7 +84,7 @@ impl fmt::Display for LexBuildError {
     }
 }
 
-pub fn build_lex<TokId: Copy + Eq + TryFrom<usize>>(s: &str) -> Result<Lexer<TokId>, LexBuildError> {
+pub fn build_lex<TokId: Copy + Eq + TryFrom<usize>>(s: &str) -> Result<LexerDef<TokId>, LexBuildError> {
     parse_lex(s)
 }
 

--- a/src/lib/parser.rs
+++ b/src/lib/parser.rs
@@ -35,7 +35,7 @@ use std::convert::TryFrom;
 use regex::{Regex, RegexBuilder};
 
 use {LexErrorKind, LexBuildError, LexBuildResult};
-use lexer::{Lexer, Rule};
+use lexer::{LexerDef, Rule};
 
 pub struct LexParser<TokId> {
     src: String,
@@ -187,8 +187,8 @@ impl<TokId: TryFrom<usize>> LexParser<TokId> {
     }
 }
 
-pub fn parse_lex<TokId: Copy + Eq + TryFrom<usize>>(s: &str) -> LexBuildResult<Lexer<TokId>> {
-    LexParser::new(s.to_string()).map(|p| Lexer::new(p.rules))
+pub fn parse_lex<TokId: Copy + Eq + TryFrom<usize>>(s: &str) -> LexBuildResult<LexerDef<TokId>> {
+    LexParser::new(s.to_string()).map(|p| LexerDef::new(p.rules))
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ use std::fs::File;
 use std::io::{Read, stderr, Write};
 use std::path::Path;
 
-use lrlex::{build_lex, Lexer};
+use lrlex::{build_lex, LexerDef};
 
 fn usage(prog: String, msg: &str) {
     let path = Path::new(prog.as_str());
@@ -85,13 +85,13 @@ fn main() {
     }
 
     let lex_l_path = &matches.free[0];
-    let lexer: Lexer<usize> = build_lex(&read_file(lex_l_path)).unwrap_or_else(|s| {
+    let lexerdef: LexerDef<usize> = build_lex(&read_file(lex_l_path)).unwrap_or_else(|s| {
             writeln!(&mut stderr(), "{}: {}", &lex_l_path, &s).ok();
             process::exit(1);
         });
     let input = &read_file(&matches.free[1]);
-    let lexemes = lexer.lex(&input).unwrap();
+    let lexemes = lexerdef.lexer(&input).lexemes().unwrap();
     for l in lexemes.iter() {
-        println!("{} {}", lexer.get_rule_by_id(l.tok_id()).unwrap().name.as_ref().unwrap(), &input[l.start()..l.start() + l.len()]);
+        println!("{} {}", lexerdef.get_rule_by_id(l.tok_id()).unwrap().name.as_ref().unwrap(), &input[l.start()..l.start() + l.len()]);
     }
 }


### PR DESCRIPTION
This adjusts lrlex to gain support for finding out (line, col) numbers for lexemes. The two commits hopefully make things clear.

Sarah: before we think about merging this, can you see if the altered API works OK for you? I think it's a reasonable design, but I'd like to check that before we go ahead!

[One thing that's implicit in this commit is that I've tried to structure things in a way that, in the future, we can run a lexer and parser in parallel to each other. Is that a good idea? No idea!]