### PR TITLE
Throw an error if lexemes that aren't referenced in the parser are encountered

### DIFF
--- a/src/lib/parser.rs
+++ b/src/lib/parser.rs
@@ -157,7 +157,7 @@ impl<TokId: TryFrom<usize>> LexParser<TokId> {
         let rules_len = self.rules.len();
         let tok_id = TokId::try_from(rules_len)
                            .unwrap_or_else(|_| panic!("TokId::try_from failed on {} (if TokId is an unsigned integer type, this probably means that {} exceeds the type's maximum value)", rules_len, rules_len));
-        self.rules.push(Rule{tok_id: tok_id,
+        self.rules.push(Rule{tok_id: Some(tok_id),
                              name: name,
                              re: re,
                              re_str: re_str});

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,6 +92,6 @@ fn main() {
     let input = &read_file(&matches.free[1]);
     let lexemes = lexerdef.lexer(input).lexemes().unwrap();
     for l in lexemes.iter() {
-        println!("{} {}", lexerdef.get_rule_by_id(l.tok_id()).unwrap().name.as_ref().unwrap(), &input[l.start()..l.start() + l.len()]);
+        println!("{} {}", lexerdef.get_rule_by_id(l.tok_id()).name.as_ref().unwrap(), &input[l.start()..l.start() + l.len()]);
     }
 }


### PR DESCRIPTION
As such, lrlex's original behaviour was defensible: it's not really its problem whether a lexing rule is used by the parser or not. *But* it causes a subtle problem with the ID mapping: if the parser doesn't say that rule R has id X, then rule R ends up with a completely random id that baffles the parser. While we could come up with a complex API (and I wasted way too much time trying to think of such an API) to allow the parser to deal with such lexemes, they're rare enough that the complexity seems worthless: better to have the lexer explicitly choke on such lexemes as soon as they're encountered.

Fixes https://github.com/softdevteam/lrpar/issues/36:

```
$ cat /tmp/hang.l
%%
hang HANG
the THE
dj DJ
[ \t\n\r]+ ;
\+   PLUS
$ cat /tmp/hang.y
%start lines
%%
lines : lines line | line;
line : "HANG" "THE" "DJ";
$ cat /tmp/hang
hang the dj + hang the dj +
$ cargo run /tmp/hang.l /tmp/hang.y /tmp/hang
     Running `target/debug/lrpar /tmp/hang.l /tmp/hang.y /tmp/hang`
Warning: these tokens are defined in the lexer but not referenced in the
grammar:
  PLUS
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: LexError { idx: 12 }', /home/ltratt/tmp/rust/src/libcore/result.rs:906:4
```

OK, the error reported is not elegant, but at least it stops complete mayhem from occurring.