### PR TITLE
Be less strict about rule names.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,4 @@ path = "src/lib/mod.rs"
 
 [dependencies]
 getopts = "0.2.15" # only needed for src/main.rs
-lazy_static = "0.2.8"
 regex = "0.2.2"

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -43,9 +43,6 @@ mod parser;
 pub use lexer::{Lexeme, LexerDef, Lexer};
 use parser::parse_lex;
 
-#[macro_use]
-extern crate lazy_static;
-
 pub type LexBuildResult<T> = Result<T, LexBuildError>;
 
 /// Any error from the Lex parser returns an instance of this struct.
@@ -63,7 +60,6 @@ pub enum LexErrorKind {
     RoutinesNotSupported,
     UnknownDeclaration,
     MissingSpace,
-    InvalidName,
     DuplicateName,
     RegexError
 }
@@ -76,7 +72,6 @@ impl fmt::Display for LexBuildError {
             LexErrorKind::RoutinesNotSupported => s = "Routines not currently supported",
             LexErrorKind::UnknownDeclaration   => s = "Unknown declaration",
             LexErrorKind::MissingSpace         => s = "Rule is missing a space",
-            LexErrorKind::InvalidName          => s = "Invalid rule name",
             LexErrorKind::DuplicateName        => s = "Rule name already exists",
             LexErrorKind::RegexError           => s = "Invalid regular expression"
         }


### PR DESCRIPTION
Previously we forced rule names to be "standard" identifiers. But this means that you couldn't write rules such as:

```
  \\+ +
```

which is really rather annoying. This commit simply removes this restriction: in essence, all the non-whitespace chars after the last space in the line become the rule name. So the above says "the regular expression \\+ has the name +".

An interesting question is: why was this restriction in place? Well, it
more-or-less matches lex, in the sense that Lex would write the above as: 

```
  \\+ { return PLUS; }
```

Where PLUS is a C-level identifier shared between yacc and lex. Because this is annoying to use in grammars, yacc allows you to specify single-character string literals in grammars:

```
  expr: expr '+' expr;
```

and so on. In such cases yacc does some lexing of its own before calling lex (via the yylex() function)! That just seems backwards (or forwards, or whatever the opposite of the "right way to do it" is) to me.

My conclusion: we ended up following the restrictions of a weird hack that relied on C identifiers. Ultimately, we can rid ourselves of this problem and still remain almost 100% lex/yacc compatible. The only thing is that if someone uses string literals in their yacc grammar, they'll have to define a token in their lex file. This seems like a very minor imposition.