### PR TITLE
Rule names now need to be quoted.

### DIFF
--- a/src/lib/lexer.rs
+++ b/src/lib/lexer.rs
@@ -277,8 +277,8 @@ mod test {
     fn test_basic() {
         let src = r"
 %%
-[0-9]+ int
-[a-zA-Z]+ id
+[0-9]+ 'int'
+[a-zA-Z]+ 'id'
 [ \t] ;
         ".to_string();
         let mut lexer = parse_lex(&src).unwrap();
@@ -303,7 +303,7 @@ mod test {
     fn test_basic_error() {
         let src = "
 %%
-[0-9]+ int
+[0-9]+ 'int'
         ".to_string();
         let lexer = parse_lex::<u8>(&src).unwrap();
         match lexer.lexer(&"abc").lexemes() {
@@ -316,8 +316,8 @@ mod test {
     #[test]
     fn test_longest_match() {
         let src = "%%
-if IF
-[a-z]+ ID
+if 'IF'
+[a-z]+ 'ID'
 [ ] ;".to_string();
         let mut lexer = parse_lex(&src).unwrap();
         let mut map = HashMap::new();
@@ -340,7 +340,7 @@ if IF
     #[test]
     fn test_line_and_col() {
         let src = "%%
-[a-z]+ ID
+[a-z]+ 'ID'
 [ \\n] ;".to_string();
         let mut lexerdef = parse_lex(&src).unwrap();
         let mut map = HashMap::new();
@@ -374,7 +374,7 @@ if IF
     #[test]
     fn test_missing_from_lexer_and_parser() {
         let src = "%%
-[a-z]+ ID
+[a-z]+ 'ID'
 [ \\n] ;".to_string();
         let mut lexerdef = parse_lex(&src).unwrap();
         let mut map = HashMap::new();

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -60,6 +60,7 @@ pub enum LexErrorKind {
     RoutinesNotSupported,
     UnknownDeclaration,
     MissingSpace,
+    InvalidName,
     DuplicateName,
     RegexError
 }
@@ -72,6 +73,7 @@ impl fmt::Display for LexBuildError {
             LexErrorKind::RoutinesNotSupported => s = "Routines not currently supported",
             LexErrorKind::UnknownDeclaration   => s = "Unknown declaration",
             LexErrorKind::MissingSpace         => s = "Rule is missing a space",
+            LexErrorKind::InvalidName          => s = "Invalid rule name",
             LexErrorKind::DuplicateName        => s = "Rule name already exists",
             LexErrorKind::RegexError           => s = "Invalid regular expression"
         }


### PR DESCRIPTION
We opened up a can of worms (which, admittedly, we should have addressed anyway) with 7b1e3056. We allowed things like this:

```
  - -
```

i.e. a rule with the regex "-" (LHS) and the name "-" (RHS). That works well for nearly all cases, *except* we inherited from lex this idiom:

```
  [ \t\n\r]+ ;
```

where a rule name of ";" means "don't generate any tokens for the matched tests." This raises an obvious problem for this rule:

```
  ; ;
```

which a user would probably think means "match semicolons and create tokens named ';'". But it means discard the matching text. Oops.

This PR forces rule names to be quoted (either 'xxx' or "xxx"), so these are all valid:

```
  - "-"
  ; ";"
  [ \t\n\r] ;
```

which will produce tokens name "-" and ";", but which ignores whitespace.